### PR TITLE
Adds Donksoft Toy Vendor (Machine Board) to Circuit Imprinter and more

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1167,6 +1167,30 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/donksoft
 
+/obj/machinery/vending/donksofttoyvendor
+	name = "\improper Donksoft Toy Vendor"
+	desc = "A ages 8 and up approved vendor that dispenses toys. If you were to find the right wires, you can unlock the adult mode setting!"
+	icon_state = "syndi"
+	product_slogans = "Get your cool toys today!;Trigger a valid hunter today!;Quality toy weapons for cheap prices!;Give them to HoPs for all access!;Give them to HoS to get perma briged!"
+	product_ads = "Feel robust with your toys!;Express your inner child today!;Toy weapons don't kill people, but valid hunters do!;Who needs responsibilities when you have toy weapons?;Make your next murder FUN!"
+	vend_reply = "Come back for more!"
+	products = list(/obj/item/gun/ballistic/automatic/toy/unrestricted = 10,
+					/obj/item/gun/ballistic/automatic/toy/pistol/unrestricted = 10,
+					/obj/item/gun/ballistic/shotgun/toy/unrestricted = 10,
+					/obj/item/toy/sword = 10, /obj/item/ammo_box/foambox = 20,
+					/obj/item/toy/foamblade = 10,
+					/obj/item/toy/syndicateballoon = 10,
+					/obj/item/clothing/suit/syndicatefake = 5,
+					/obj/item/clothing/head/syndicatefake = 5)
+	contraband = list(/obj/item/gun/ballistic/shotgun/toy/crossbow = 10,
+						/obj/item/gun/ballistic/automatic/c20r/toy/unrestricted = 10,
+						/obj/item/gun/ballistic/automatic/l6_saw/toy/unrestricted = 10,
+						/obj/item/toy/katana = 10,
+						/obj/item/twohanded/dualsaber/toy = 5)
+	armor = list(melee = 100, bullet = 100, laser = 100, energy = 100, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 50)
+	resistance_flags = FIRE_PROOF
+	refill_canister = /obj/item/vending_refill/donksoft
+
 #undef STANDARD_CHARGE
 #undef CONTRABAND_CHARGE
 #undef COIN_CHARGE

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -723,9 +723,9 @@
 		/obj/item/stock_parts/console_screen = 1,
 		/obj/item/stack/sheet/glass = 1)
 
-/obj/item/circuitboard/machine/vending/toyliberationstation
+/obj/item/circuitboard/machine/vending/donksofttoyvendor
 	name = "Donksoft Toy Vendor (Machine Board)"
-	build_path = /obj/machinery/vending/toyliberationstation
+	build_path = /obj/machinery/vending/donksofttoyvendor
 	origin_tech = "programming=1;syndicate=2"
 	req_components = list(
 		/obj/item/stock_parts/console_screen = 1,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1648,7 +1648,7 @@
 	                /obj/item/stack/tile/fakespace/loaded,
 	                /obj/item/gun/ballistic/shotgun/toy/crossbow,
 	                /obj/item/toy/redbutton,
-					/obj/item/toy/eightball
+					/obj/item/toy/eightball,
 					/obj/item/vending_refill/donksoft)
 	crate_name = "toy crate"
 

--- a/code/modules/projectiles/boxes_magazines/external_mag.dm
+++ b/code/modules/projectiles/boxes_magazines/external_mag.dm
@@ -294,7 +294,7 @@
 		icon_state = "smg9mm-0"
 
 /obj/item/ammo_box/magazine/toy/smg/riot
-	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot
+	ammo_type = /obj/item/ammo_casing/caseless/foam_dart
 
 /obj/item/ammo_box/magazine/toy/pistol
 	name = "foam force pistol magazine"
@@ -303,12 +303,12 @@
 	multiple_sprites = 2
 
 /obj/item/ammo_box/magazine/toy/pistol/riot
-	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot
+	ammo_type = /obj/item/ammo_casing/caseless/foam_dart
 
 /obj/item/ammo_box/magazine/toy/smgm45
 	name = "donksoft SMG magazine"
 	caliber = "foam_force"
-	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot
+	ammo_type = /obj/item/ammo_casing/caseless/foam_dart
 	max_ammo = 20
 
 /obj/item/ammo_box/magazine/toy/smgm45/update_icon()
@@ -318,7 +318,7 @@
 /obj/item/ammo_box/magazine/toy/m762
 	name = "donksoft box magazine"
 	caliber = "foam_force"
-	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot
+	ammo_type = /obj/item/ammo_casing/caseless/foam_dart
 	max_ammo = 50
 
 /obj/item/ammo_box/magazine/toy/m762/update_icon()

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -419,10 +419,10 @@
 	build_path = /obj/item/circuitboard/machine/deep_fryer
 	category = list ("Misc. Machinery")
 
-/datum/design/board/toyliberationstation
+/datum/design/board/donksofttoyvendor
 	name = "Machine Design (Donksoft Toy Vendor Board)"
 	desc = "The circuit board for a Donksoft Toy Vendor."
-	id = "toyliberationstation"
+	id = "donksofttoyvendor"
 	req_tech = list("programming" = 1, "syndicate" = 2)
-	build_path = /obj/item/circuitboard/machine/vending/toyliberationstation
+	build_path = /obj/item/circuitboard/machine/vending/donksofttoyvendor
 	category = list ("Misc. Machinery")


### PR DESCRIPTION
:cl: Kerbin_Fiber
* add: Donksoft Toy Vendor Boards to the Circuit Imprinter when Illegal tech is high enough.
* add: Donksoft Toy Vendor Restocking Units come in Toy Crates from Cargo!
* add: Donksoft Toy Vendor is different than the Syndicate Donksoft Toy Vendor, it has **NO RIOT FOAM DARTS**
/:cl:
![donksoftrestockingunit](https://user-images.githubusercontent.com/31713423/30152348-6fb2561a-9378-11e7-9923-dec4ce936b17.PNG)

Why? Because it's no fair for the Syndicates to be able to have ~~fun~~ toys and we don't! Once the research from illegal items that were ~~stolen~~ obtained have been deconstructed, the Circuit Imprinter will be able to print out Donksoft Toy Vendor (Machine Board)s!
